### PR TITLE
Fix lambda capture in WiredRdTaskImpl, throwing a warning in Clang 18.1.8.

### DIFF
--- a/src/cpp/RiderLink/Source/RD/src/rd_framework_cpp/src/main/task/WiredRdTaskImpl.h
+++ b/src/cpp/RiderLink/Source/RD/src/rd_framework_cpp/src/main/task/WiredRdTaskImpl.h
@@ -47,15 +47,15 @@ public:
 		spdlog::get("logReceived")
 			->trace("call {} {} received response {} : {}", to_string(cutpoint->get_location()), to_string(rdid), to_string(rdid),
 				to_string(read_result));
-		scheduler->queue([&, result = std::move(read_result)]() mutable {
+		scheduler->queue([this, read_result = std::move(read_result)]() mutable {
 			if (this->result->has_value())
 			{
 				spdlog::get("logReceived")->trace("call {} {} response was dropped, task result is: {}", to_string(location), to_string(rdid),
-					to_string(result.unwrap()));
+					to_string(read_result.unwrap()));
 			}
 			else
 			{
-				this->result->set_if_empty(std::move(result));
+				this->result->set_if_empty(std::move(read_result));
 			}
 		});
 	}


### PR DESCRIPTION
The `result` capture by move is shadowing the `result` member of this class, throwing a warning/error in Clang 18.1.8. There is no need to capture all either, so using `this` instead of `&` and renaming `result` by `name_result` fix the issue.